### PR TITLE
Fix locon dora initialization with lora extract

### DIFF
--- a/lycoris/kohya.py
+++ b/lycoris/kohya.py
@@ -63,6 +63,22 @@ def create_network(
     rs_lora = str_bool(kwargs.get("rs_lora", False))
     unbalanced_factorization = str_bool(kwargs.get("unbalanced_factorization", False))
     train_t5xxl = str_bool(kwargs.get("train_t5xxl", False))
+    # dora controls
+    dora_lr_ratio = (
+        float(kwargs.get("dora_lr_ratio", None))
+        if kwargs.get("dora_lr_ratio", None) is not None
+        else None
+    )
+    dora_clip_min = (
+        float(kwargs.get("dora_clip_min", None))
+        if kwargs.get("dora_clip_min", None) is not None
+        else None
+    )
+    dora_clip_max = (
+        float(kwargs.get("dora_clip_max", None))
+        if kwargs.get("dora_clip_max", None) is not None
+        else None
+    )
     # lora_plus
     loraplus_lr_ratio = (
         float(kwargs.get("loraplus_lr_ratio", None))
@@ -132,6 +148,9 @@ def create_network(
         rs_lora=rs_lora,
         unbalanced_factorization=unbalanced_factorization,
         train_t5xxl=train_t5xxl,
+        dora_lr_ratio=dora_lr_ratio,
+        dora_clip_min=dora_clip_min,
+        dora_clip_max=dora_clip_max,
     )
     if (
         loraplus_lr_ratio is not None
@@ -322,6 +341,9 @@ class LycorisNetworkKohya(LycorisNetwork):
         norm_modules=NormModule,
         train_norm=False,
         train_t5xxl=False,
+        dora_lr_ratio=None,
+        dora_clip_min=None,
+        dora_clip_max=None,
         **kwargs,
     ) -> None:
         torch.nn.Module.__init__(self)
@@ -334,6 +356,11 @@ class LycorisNetworkKohya(LycorisNetwork):
         self.loraplus_lr_ratio = None
         self.loraplus_unet_lr_ratio = None
         self.loraplus_text_encoder_lr_ratio = None
+
+        # dora controls
+        self.dora_lr_ratio = dora_lr_ratio
+        self.dora_clip_min = dora_clip_min
+        self.dora_clip_max = dora_clip_max
 
         if not self.ENABLE_CONV:
             conv_lora_dim = 0
@@ -672,11 +699,13 @@ class LycorisNetworkKohya(LycorisNetwork):
         lr_descriptions = []
 
         def assemble_params(loras, lr, ratio):
-            param_groups = {"lora": {}, "plus": {}}
+            param_groups = {"lora": {}, "plus": {}, "dora": {}}
             for lora in loras:
                 for name, param in lora.named_parameters():
                     if ratio is not None and "lora_up" in name:
                         param_groups["plus"][f"{lora.lora_name}.{name}"] = param
+                    elif "dora_scale" in name:
+                        param_groups["dora"][f"{lora.lora_name}.{name}"] = param
                     else:
                         param_groups["lora"][f"{lora.lora_name}.{name}"] = param
 
@@ -691,6 +720,8 @@ class LycorisNetworkKohya(LycorisNetwork):
                 if lr is not None:
                     if key == "plus":
                         param_data["lr"] = lr * ratio
+                    elif key == "dora" and self.dora_lr_ratio is not None:
+                        param_data["lr"] = lr * self.dora_lr_ratio
                     else:
                         param_data["lr"] = lr
 
@@ -702,7 +733,12 @@ class LycorisNetworkKohya(LycorisNetwork):
                     continue
 
                 params.append(param_data)
-                descriptions.append("plus" if key == "plus" else "")
+                if key == "plus":
+                    descriptions.append("plus")
+                elif key == "dora":
+                    descriptions.append("dora")
+                else:
+                    descriptions.append("")
 
             return params, descriptions
 
@@ -741,7 +777,18 @@ class LycorisNetworkKohya(LycorisNetwork):
         self.train()
 
     def on_step_start(self, *args):
-        pass
+        # Clamp DoRA scales if requested
+        if self.dora_clip_min is None and self.dora_clip_max is None:
+            return
+        clip_min = self.dora_clip_min
+        clip_max = self.dora_clip_max
+        for lora in self.unet_loras + self.text_encoder_loras:
+            if hasattr(lora, "wd") and lora.wd and hasattr(lora, "dora_scale"):
+                with torch.no_grad():
+                    lora.dora_scale.data.clamp_(
+                        clip_min if clip_min is not None else -torch.inf,
+                        clip_max if clip_max is not None else torch.inf,
+                    )
 
     def get_trainable_params(self):
         return self.parameters()

--- a/lycoris/modules/locon.py
+++ b/lycoris/modules/locon.py
@@ -183,16 +183,13 @@ class LoConModule(LycorisBaseModule):
 
     def load_weight_hook(self, module: nn.Module, incompatible_keys):
         missing_keys = incompatible_keys.missing_keys
+        need_recompute_dora = False
         for key in list(missing_keys):
             if "scalar" in key:
                 del missing_keys[missing_keys.index(key)]
-            # Backward compatibility: if training with DoRA but loading LoRA weights without dora_scale
-            # initialize dora_scale to 1.0 (neutral) so it doesn't over-scale.
+            # If dora_scale missing in incoming weights, mark to recompute from merged weight
             if "dora_scale" in key and hasattr(self, "dora_scale"):
-                if isinstance(self.dora_scale, nn.Parameter):
-                    self.dora_scale.data.copy_(torch.ones_like(self.dora_scale))
-                else:
-                    self.dora_scale.copy_(torch.ones_like(self.dora_scale))
+                need_recompute_dora = True
                 del missing_keys[missing_keys.index(key)]
         if isinstance(self.scalar, nn.Parameter):
             self.scalar.data.copy_(torch.ones_like(self.scalar))
@@ -202,6 +199,32 @@ class LoConModule(LycorisBaseModule):
             self.register_buffer(
                 "scalar", torch.ones_like(self.scalar), persistent=False
             )
+        # Recompute dora_scale from current merged weights for stability
+        if self.wd and need_recompute_dora:
+            with torch.no_grad():
+                dtype = self.dtype
+                device = self.org_module[0].weight.device
+                diff_weight = self.make_weight(device=device).to(dtype) * self.scale
+                weight = self.org_module[0].weight.data.to(dtype)
+                merged = weight + diff_weight
+                if self.wd_on_out:
+                    weight_norm = (
+                        merged.reshape(merged.shape[0], -1)
+                        .norm(dim=1, keepdim=True)
+                        .reshape(merged.shape[0], *[1] * (merged.dim() - 1))
+                    )
+                else:
+                    weight_norm = (
+                        merged.transpose(1, 0)
+                        .reshape(merged.shape[1], -1)
+                        .norm(dim=1, keepdim=True)
+                        .reshape(merged.shape[1], *[1] * (merged.dim() - 1))
+                        .transpose(1, 0)
+                    )
+                if isinstance(self.dora_scale, nn.Parameter):
+                    self.dora_scale.data.copy_(weight_norm.to(self.dora_scale))
+                else:
+                    self.dora_scale.copy_(weight_norm.to(self.dora_scale))
 
     def make_weight(self, device=None):
         wa = self.lora_up.weight.to(device)

--- a/lycoris/modules/locon.py
+++ b/lycoris/modules/locon.py
@@ -199,26 +199,22 @@ class LoConModule(LycorisBaseModule):
             self.register_buffer(
                 "scalar", torch.ones_like(self.scalar), persistent=False
             )
-        # Recompute dora_scale from current merged weights for stability
+        # Recompute dora_scale from original weight norm for stability
         if self.wd and need_recompute_dora:
             with torch.no_grad():
-                dtype = self.dtype
-                device = self.org_module[0].weight.device
-                diff_weight = self.make_weight(device=device).to(dtype) * self.scale
-                weight = self.org_module[0].weight.data.to(dtype)
-                merged = weight + diff_weight
+                weight = self.org_module[0].weight.data.float()
                 if self.wd_on_out:
                     weight_norm = (
-                        merged.reshape(merged.shape[0], -1)
+                        weight.reshape(weight.shape[0], -1)
                         .norm(dim=1, keepdim=True)
-                        .reshape(merged.shape[0], *[1] * (merged.dim() - 1))
+                        .reshape(weight.shape[0], *[1] * (weight.dim() - 1))
                     )
                 else:
                     weight_norm = (
-                        merged.transpose(1, 0)
-                        .reshape(merged.shape[1], -1)
+                        weight.transpose(1, 0)
+                        .reshape(weight.shape[1], -1)
                         .norm(dim=1, keepdim=True)
-                        .reshape(merged.shape[1], *[1] * (merged.dim() - 1))
+                        .reshape(weight.shape[1], *[1] * (weight.dim() - 1))
                         .transpose(1, 0)
                     )
                 if isinstance(self.dora_scale, nn.Parameter):

--- a/lycoris/modules/locon.py
+++ b/lycoris/modules/locon.py
@@ -183,8 +183,16 @@ class LoConModule(LycorisBaseModule):
 
     def load_weight_hook(self, module: nn.Module, incompatible_keys):
         missing_keys = incompatible_keys.missing_keys
-        for key in missing_keys:
+        for key in list(missing_keys):
             if "scalar" in key:
+                del missing_keys[missing_keys.index(key)]
+            # Backward compatibility: if training with DoRA but loading LoRA weights without dora_scale
+            # initialize dora_scale to 1.0 (neutral) so it doesn't over-scale.
+            if "dora_scale" in key and hasattr(self, "dora_scale"):
+                if isinstance(self.dora_scale, nn.Parameter):
+                    self.dora_scale.data.copy_(torch.ones_like(self.dora_scale))
+                else:
+                    self.dora_scale.copy_(torch.ones_like(self.dora_scale))
                 del missing_keys[missing_keys.index(key)]
         if isinstance(self.scalar, nn.Parameter):
             self.scalar.data.copy_(torch.ones_like(self.scalar))

--- a/lycoris/modules/lokr.py
+++ b/lycoris/modules/lokr.py
@@ -359,25 +359,22 @@ class LokrModule(LycorisBaseModule):
             self.register_buffer(
                 "scalar", torch.ones_like(self.scalar), persistent=False
             )
-        # Recompute dora_scale from current merged weights for stability
+        # Recompute dora_scale from original weight norm for stability
         if self.wd and need_recompute_dora:
             with torch.no_grad():
-                dtype = self.dtype
-                device = self.org_module[0].weight.device
-                diff_weight = self.get_weight(self.shape).to(dtype)
-                merged = self.org_module[0].weight.data.to(dtype) + diff_weight
+                weight = self.org_module[0].weight.data.float()
                 if self.wd_on_out:
                     weight_norm = (
-                        merged.reshape(merged.shape[0], -1)
+                        weight.reshape(weight.shape[0], -1)
                         .norm(dim=1, keepdim=True)
-                        .reshape(merged.shape[0], *[1] * (merged.dim() - 1))
+                        .reshape(weight.shape[0], *[1] * (weight.dim() - 1))
                     )
                 else:
                     weight_norm = (
-                        merged.transpose(0, 1)
-                        .reshape(merged.shape[1], -1)
+                        weight.transpose(0, 1)
+                        .reshape(weight.shape[1], -1)
                         .norm(dim=1, keepdim=True)
-                        .reshape(merged.shape[1], *[1] * (merged.dim() - 1))
+                        .reshape(weight.shape[1], *[1] * (weight.dim() - 1))
                         .transpose(0, 1)
                     )
                 if isinstance(self.dora_scale, nn.Parameter):

--- a/lycoris/modules/lokr.py
+++ b/lycoris/modules/lokr.py
@@ -343,8 +343,15 @@ class LokrModule(LycorisBaseModule):
 
     def load_weight_hook(self, module: nn.Module, incompatible_keys):
         missing_keys = incompatible_keys.missing_keys
-        for key in missing_keys:
+        for key in list(missing_keys):
             if "scalar" in key:
+                del missing_keys[missing_keys.index(key)]
+            # Backward compatibility for DoRA: initialize absent dora_scale to 1.0
+            if "dora_scale" in key and hasattr(self, "dora_scale"):
+                if isinstance(self.dora_scale, nn.Parameter):
+                    self.dora_scale.data.copy_(torch.ones_like(self.dora_scale))
+                else:
+                    self.dora_scale.copy_(torch.ones_like(self.dora_scale))
                 del missing_keys[missing_keys.index(key)]
         if isinstance(self.scalar, nn.Parameter):
             self.scalar.data.copy_(torch.ones_like(self.scalar))

--- a/lycoris/modules/lokr.py
+++ b/lycoris/modules/lokr.py
@@ -343,15 +343,13 @@ class LokrModule(LycorisBaseModule):
 
     def load_weight_hook(self, module: nn.Module, incompatible_keys):
         missing_keys = incompatible_keys.missing_keys
+        need_recompute_dora = False
         for key in list(missing_keys):
             if "scalar" in key:
                 del missing_keys[missing_keys.index(key)]
-            # Backward compatibility for DoRA: initialize absent dora_scale to 1.0
+            # Mark to recompute dora_scale from merged weight if missing
             if "dora_scale" in key and hasattr(self, "dora_scale"):
-                if isinstance(self.dora_scale, nn.Parameter):
-                    self.dora_scale.data.copy_(torch.ones_like(self.dora_scale))
-                else:
-                    self.dora_scale.copy_(torch.ones_like(self.dora_scale))
+                need_recompute_dora = True
                 del missing_keys[missing_keys.index(key)]
         if isinstance(self.scalar, nn.Parameter):
             self.scalar.data.copy_(torch.ones_like(self.scalar))
@@ -361,6 +359,31 @@ class LokrModule(LycorisBaseModule):
             self.register_buffer(
                 "scalar", torch.ones_like(self.scalar), persistent=False
             )
+        # Recompute dora_scale from current merged weights for stability
+        if self.wd and need_recompute_dora:
+            with torch.no_grad():
+                dtype = self.dtype
+                device = self.org_module[0].weight.device
+                diff_weight = self.get_weight(self.shape).to(dtype)
+                merged = self.org_module[0].weight.data.to(dtype) + diff_weight
+                if self.wd_on_out:
+                    weight_norm = (
+                        merged.reshape(merged.shape[0], -1)
+                        .norm(dim=1, keepdim=True)
+                        .reshape(merged.shape[0], *[1] * (merged.dim() - 1))
+                    )
+                else:
+                    weight_norm = (
+                        merged.transpose(0, 1)
+                        .reshape(merged.shape[1], -1)
+                        .norm(dim=1, keepdim=True)
+                        .reshape(merged.shape[1], *[1] * (merged.dim() - 1))
+                        .transpose(0, 1)
+                    )
+                if isinstance(self.dora_scale, nn.Parameter):
+                    self.dora_scale.data.copy_(weight_norm.to(self.dora_scale))
+                else:
+                    self.dora_scale.copy_(weight_norm.to(self.dora_scale))
 
     def get_weight(self, shape):
         weight = make_kron(


### PR DESCRIPTION
Initialize missing `dora_scale` to 1.0 during weight loading to enable backward-compatible LoCon+DoRA training with non-DoRA LoRA weights.

When training LoCon with DoRA enabled (`dora_wd=True`) and loading existing LoRA weights (e.g., SVD-extracted) that do not contain `dora_scale` parameters, the missing scales were causing unintended over-amplification, leading to unstable and over-saturated training. This change provides a neutral starting point for `dora_scale` when it's absent, ensuring correct DoRA behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae557b48-d51c-498f-83bb-431b2397eb96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae557b48-d51c-498f-83bb-431b2397eb96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

